### PR TITLE
chore: replace nokogiri with oga

### DIFF
--- a/SimpleWhatWeb.gemspec
+++ b/SimpleWhatWeb.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "webmock", "~> 3.4"
 
   spec.add_dependency "http", "~> 3.3"
+  spec.add_dependency "oga", "~> 2.15"
   spec.add_dependency "require_all", "~> 2.0"
-  spec.add_dependency "sanitize", "~> 4.6"
   spec.add_dependency "thor", "~> 0.19"
 end

--- a/lib/whatweb/helper.rb
+++ b/lib/whatweb/helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "digest/md5"
-require "sanitize"
+require "oga"
 
 module WhatWeb
   module Helper
@@ -10,8 +10,11 @@ module WhatWeb
         Digest::MD5.hexdigest(body.to_s)
       end
 
-      def sanitized_body
-        Sanitize.document(body.to_s, elements: ["html"])
+      def text
+        doc = Oga.parse_html(body.to_s.force_encoding('UTF-8'))
+        path = /\A<body(?:\s|>)/i.match?(body.to_s) ? '/html/body' : '/html/body/node()'
+        nodes = doc.xpath(path)
+        nodes.map(&:text).join
       end
 
       def tag_pattern

--- a/lib/whatweb/matcher/ghdb.rb
+++ b/lib/whatweb/matcher/ghdb.rb
@@ -45,10 +45,10 @@ module WhatWeb
           # does it start with a - ?
           if w[0] == '-'
             # reverse true/false if it begins with a -
-            !target.sanitized_body.match? /#{Regexp.escape(w[1..-1])}/i
+            !target.text.match? /#{Regexp.escape(w[1..-1])}/i
           else
             w = w[1..-1] if w[0] == '+' # if it starts with +, ignore the 1st char
-            target.sanitized_body.match? /#{Regexp.escape(w)}/i
+            target.text.match? /#{Regexp.escape(w)}/i
           end
         end
       end

--- a/lib/whatweb/plugins/anygate.rb
+++ b/lib/whatweb/plugins/anygate.rb
@@ -1,4 +1,3 @@
-# coding: ascii-8bit
 # frozen_string_literal: true
 
 ##

--- a/lib/whatweb/plugins/bm-classifieds.rb
+++ b/lib/whatweb/plugins/bm-classifieds.rb
@@ -1,4 +1,3 @@
-# coding: ascii-8bit
 # frozen_string_literal: true
 
 ##

--- a/lib/whatweb/plugins/fidion-cms.rb
+++ b/lib/whatweb/plugins/fidion-cms.rb
@@ -1,4 +1,3 @@
-# coding: ascii-8bit
 # frozen_string_literal: true
 
 ##

--- a/lib/whatweb/plugins/mihalism-multi-host.rb
+++ b/lib/whatweb/plugins/mihalism-multi-host.rb
@@ -1,4 +1,3 @@
-# coding: ascii-8bit
 # frozen_string_literal: true
 
 ##

--- a/lib/whatweb/plugins/netsnap-web-camera.rb
+++ b/lib/whatweb/plugins/netsnap-web-camera.rb
@@ -1,4 +1,3 @@
-# coding: ascii-8bit
 # frozen_string_literal: true
 
 ##

--- a/lib/whatweb/plugins/rvi-camera.rb
+++ b/lib/whatweb/plugins/rvi-camera.rb
@@ -1,4 +1,3 @@
-# coding: ascii-8bit
 # frozen_string_literal: true
 
 ##

--- a/lib/whatweb/plugins/s-cms.rb
+++ b/lib/whatweb/plugins/s-cms.rb
@@ -1,4 +1,3 @@
-# coding: ascii-8bit
 # frozen_string_literal: true
 
 ##

--- a/lib/whatweb/plugins/samphpweb.rb
+++ b/lib/whatweb/plugins/samphpweb.rb
@@ -1,4 +1,3 @@
-# coding: ascii-8bit
 # frozen_string_literal: true
 
 ##

--- a/lib/whatweb/plugins/snografx.rb
+++ b/lib/whatweb/plugins/snografx.rb
@@ -1,4 +1,3 @@
-# coding: ascii-8bit
 # frozen_string_literal: true
 
 ##

--- a/lib/whatweb/plugins/title.rb
+++ b/lib/whatweb/plugins/title.rb
@@ -12,7 +12,7 @@
 # Version 0.2
 # removed :certainty=>100
 
-require "nokogiri"
+require "oga"
 
 WhatWeb::Plugin.define "Title" do
   @author = "Andrew Horton"
@@ -22,8 +22,8 @@ WhatWeb::Plugin.define "Title" do
   def passive(target)
     m = []
 
-    html = Nokogiri.parse(target.body)
-    title = html.css("title")
+    html = Oga.parse_html(target.body)
+    title = html.at_css("title")
     if title
       # Give warining if title element contains newline(s)
       m << { name: "WARNING", module: "Title element contains newline(s)!" } if title.text.include? "\n"

--- a/lib/whatweb/target.rb
+++ b/lib/whatweb/target.rb
@@ -40,8 +40,8 @@ module WhatWeb
       @tag_pattern ||= response.tag_pattern
     end
 
-    def sanitized_body
-      @sanitized_body ||= response.sanitized_body
+    def text
+      @text ||= response.text
     end
 
     def self.meta_refresh_regex

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe WhatWeb::CLI, vcr: vcr_options do
         output = capture(:stdout) { subject.start %w(scan https://github.com) }
         json = JSON.parse(output)
         expect(json).to be_a(Hash)
+        expect(json.dig("Title").first.dig("string")).to eq("The world’s leading software development platform · GitHub")
       end
     end
   end


### PR DESCRIPTION
Replace `nokogiri` with `oga` for reducing dependencies.